### PR TITLE
Update price import to use new format of OLCC CSV

### DIFF
--- a/django_olcc/olcc/management/commands/olccimport.py
+++ b/django_olcc/olcc/management/commands/olccimport.py
@@ -71,10 +71,19 @@ class Command(BaseCommand):
                 if row.get('proof'):
                     product.proof = row.get('proof')
                 if row.get('age'):
-                    if row.get('age_unit') == 'M':
-                        product.age = int(float(row.get('age'))) / 12
+                    if 'age_unit' in row:
+                        # old format (age + age unit)
+                        if row.get('age_unit') == 'M':
+                            product.age = int(float(row.get('age'))) / 12
+                        else:
+                            product.age = row.get('age')
                     else:
-                        product.age = row.get('age')
+                        # new format ('24 YRS')
+                        m = re.search('(\\d+) (YRS?|MOS?)', row.get('age'))
+                        if m.group(2).startswith('MO'):
+                            product.age = int(float(m.group(1))) / 12
+                        elif m.group(2).startswith('YR'):
+                            product.age = m.group(1)
 
                 # Persist our updates
                 product.save()
@@ -114,7 +123,8 @@ class Command(BaseCommand):
         """
         Import a list of price and product data from the given CSV reader.
         """
-        keys = ['code', 'status', 'title', 'size', 'per_case', 'price', 'price_effective_date']
+        keys = ['code', 'status', 'title', 'size', 'age', 'proof', 'per_case',
+                'price', 'price_effective_date']
 
         count = 0
         for row in csvreader:
@@ -181,7 +191,8 @@ class Command(BaseCommand):
         Import a list of price and product data from the given
         sheet from an Excel workbook.
         """
-        keys = ['code', 'status', 'title', 'size', 'per_case', 'price']
+        keys = ['code', 'status', 'title', 'size', 'age', 'proof', 'per_case',
+                'price', 'price_effective_date']
 
         count = 0
         for n in range(sheet.nrows):

--- a/django_olcc/olcc/management/commands/olccimport.py
+++ b/django_olcc/olcc/management/commands/olccimport.py
@@ -42,9 +42,8 @@ class Command(BaseCommand):
     @transaction.commit_on_success
     def product_from_row(self, row):
         """
-        Import a row of product price data as a new product record. This method
-        can import row data from both a price history file or a numeric price
-        list file.
+        Import a row of product price data as a new product record. The row data
+        should correspond to a numeric price list file.
 
         :param row: A dict of keys mapped to row values.
         :return: A tuple containing a Product instance and a boolean indicating

--- a/django_olcc/olcc/tests.py
+++ b/django_olcc/olcc/tests.py
@@ -205,9 +205,9 @@ class TestImportCommand(TestCase):
         ]
 
         self.prices = [
-            ('0102B', '@', 'GLENFIDDICH SNOW PHOENIX', '750 ML', 6, 92.95),
-            ('0103B', '', 'BALVENIE 14 YR CARIBBEAN C', '750 ML', 6, 64.95),
-            ('0105B', '', 'DECO COFFEE RUM', '750 ML', 12, 23.95),
+            ('0212H', '@', 'OLD OVERHOLT', '1.75 L', '4 YRS', 80, 6, 41.95),
+            ('4176B', '@', 'COLD TREE GIN', '750 ML', '', 80, 12, 29.95),
+            ('8932B', '', 'SENOR RIO REPOSADO TEQUILA', '750 ML', '6 MOS', 80, 6, 65),
         ]
 
         self.history = [
@@ -334,7 +334,8 @@ class TestImportCommand(TestCase):
             self.assertEqual(self.prices[i][1], p.status)
             self.assertEqual(self.prices[i][2], p.title.upper())
             self.assertEqual(self.prices[i][3], p.size)
-            self.assertEqual(self.prices[i][4], p.bottles_per_case)
+            self.assertEqual(self.prices[i][5], p.proof)
+            self.assertEqual(self.prices[i][6], p.bottles_per_case)
             self.assertEqual(p.prices.count(), 1)
 
             # Verify the price data

--- a/django_olcc/olcc/tests.py
+++ b/django_olcc/olcc/tests.py
@@ -210,15 +210,6 @@ class TestImportCommand(TestCase):
             ('8932B', '', 'SENOR RIO REPOSADO TEQUILA', '750 ML', '6 MOS', 80, 6, 65),
         ]
 
-        self.history = [
-            ('2012', '7', '1241B', 'SWEET BABY MOONSHINE', '750 ML', 0, None, 95.00, 12, 25.95),
-            ('2012', '7', '1243B', 'WARSHIP SILVER RUM 125 PRO', '', 0, None, 125.00, 12, 24.95),
-            ('2012', '6', '0103B', 'BALVENIE 14 YR CARIBBEAN C', '', 14, None, 86.00, 6, 69.95),
-            ('2011', '7', '1241B', 'SWEET BABY MOONSHINE', '750 ML', 0, None, 95.00, 12, 15.95),
-            ('2011', '7', '1243B', 'WARSHIP SILVER RUM 125 PRO', '', 0, None, 125.00, 12, 14.95),
-            ('2011', '6', '0103B', 'BALVENIE 14 YR CARIBBEAN C', '', 14, None, 86.00, 6, 39.95),
-        ]
-
     def test_validation(self):
         """
         Verify the command throws the proper exceptions when
@@ -337,62 +328,6 @@ class TestImportCommand(TestCase):
             self.assertEqual(self.prices[i][5], p.proof)
             self.assertEqual(self.prices[i][6], p.bottles_per_case)
             self.assertEqual(p.prices.count(), 1)
-
-            # Verify the price data
-            price = p.prices.all()[0]
-            self.assertEqual(price.effective_date, price_date)
-
-            # Increment the counter
-            i += 1
-
-    @patch.object(xlrd, 'open_workbook')
-    def test_import_price_history(self, mock_open_workbook):
-        """
-        Test a basic price history file import.
-        """
-        # Configure our Mocks
-        sheet_mock = Mock()
-        sheet_mock.nrows = len(self.history)
-        sheet_mock.row_values = Mock(side_effect=self.history)
-
-        wb_mock = Mock(return_value=sheet_mock)
-        wb_mock.sheet_by_index = Mock(return_value=sheet_mock)
-
-        mock_open_workbook.return_value = wb_mock
-
-        # Sanity check
-        self.assertEqual(Product.objects.count(), 0)
-        self.assertEqual(ProductPrice.objects.count(), 0)
-
-        # Call our management command
-        path = 'foo/bar/baz/xml'
-        call_command('olccimport', path, quiet=True, import_type='price_history',)
-
-        # Verify open_workbook was called correctly
-        self.assertTrue(mock_open_workbook.called)
-        self.assertEqual(mock_open_workbook.call_count, 1)
-        self.assertEqual(mock_open_workbook.call_args[0][0], path)
-
-        # Verify the expected number of objects were created
-        products = Product.objects.all().order_by('pk')
-        self.assertEqual(products.count(), len(self.history) / 2)
-
-        prices = ProductPrice.objects.all().order_by('pk')
-        self.assertEqual(prices.count(), len(self.history))
-
-        # Verify the product data
-        i = 0
-        for p in products:
-            self.assertEqual(self.history[i][2], p.code)
-            self.assertEqual(self.history[i][3], p.title.upper())
-            self.assertEqual(self.history[i][4], p.size)
-            self.assertEqual(self.history[i][5], p.age)
-            self.assertEqual(self.history[i][7], p.proof)
-            self.assertEqual(p.prices.count(), 2)
-
-            # Calculate the expected price data
-            price_date = datetime.date(int(self.history[i][0]),
-                    int(self.history[i][1]), 1)
 
             # Verify the price data
             price = p.prices.all()[0]


### PR DESCRIPTION
It looks like the OLCC updated the format of [NumericPriceListNextMonth.csv](http://www.olcc.state.or.us/pdfs/NumericPriceListNextMonth.csv). These changes should allow the app to import the file once again.

I tested this by starting with a fresh clone and running `virtualenv venv && . venv/bin/activate && pip install -r requirements.txt && cd django_olcc && touch settings_local.py && python manage.py syncdb && python manage.py olccfetch && python manage.py run_gunicorn`. This seems to result in a fully populated/working app.

Hope it helps. Really appreciate your site!